### PR TITLE
stop using user.Current(); doesn't work on linux

### DIFF
--- a/rpenv.go
+++ b/rpenv.go
@@ -9,11 +9,12 @@ import (
 	"os/exec"
 	"os/user"
 	"sort"
+	"strconv"
 	"strings"
 	"syscall"
 )
 
-const AppVersion = "3.0.4"
+const AppVersion = "3.0.5"
 const ConfigPath = ".config/.rpenv"
 
 func main() {
@@ -44,7 +45,12 @@ func main() {
 }
 
 func envUri(env string) string {
-	usr, _ := user.Current()
+	usr, err := user.LookupId(strconv.Itoa(os.Getuid()))
+	if err != nil {
+		fmt.Printf("rpenv: %s\n", err)
+		os.Exit(6)
+	}
+
 	conf := getConfig(usr.HomeDir + "/" + ConfigPath, env)
 
 	return conf
@@ -131,7 +137,7 @@ func getConfig(configFile string, env string) string {
 
 	if mymap["ci"] == "" || mymap["qa"] == "" || mymap["prod"] == "" {
 		fmt.Println("You must have a ~/.config/.rpenv with ci, qa, and prod keys")
-		os.Exit(1)
+		os.Exit(4)
 	}
 
 	if env == "production" {
@@ -142,7 +148,7 @@ func getConfig(configFile string, env string) string {
 
 	if uri == "" {
 		fmt.Println("Provided environment must be one of 'ci', 'qa', 'prod', or 'production'.")
-		os.Exit(1)
+		os.Exit(5)
 	}
 
 	return uri

--- a/rpenv.spec
+++ b/rpenv.spec
@@ -1,5 +1,5 @@
 Name:   rpenv
-Version:  3.0.4
+Version:  3.0.5
 Release:  1%{?dist}
 Summary: displays env vars set from existing environment.
 Source0: rpenv.go
@@ -39,6 +39,9 @@ rm -rf %{buildroot}
 
 
 %changelog
+* Wed Feb 14 2018 Alan Voss <avoss@rentpath.com> - 3.0.5
+- Cross-compilation for linux didn't work for user dir query
+
 * Mon Feb 12 2018 Alan Voss <avoss@rentpath.com> - 3.0.4
 - Fixing README and various version errors in repo
 


### PR DESCRIPTION
[Card](https://rentpath.leankit.com/card/587077495)

`user.Current()` for whatever reason returns `nil` on `linux/amd64` (it isn't implemented), and ultimately led to segfaults on linux with the cross-compiled releases.

Switching the workflow to use `os.Getuid()` and lookup the home directory.