### PR TITLE
adding -skip-local flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 #rpenv
 
-displays env vars set from existing environment and loaded from config file in specified environment (ci, qa, or prod) or executes command in the context of the existing environment variables and ones loaded from a config file.
+displays env vars set from existing environment ( [skippable](#usage) ) and loaded from config file in specified environment (ci, qa, or prod) or executes command in the context of the existing environment variables and ones loaded from a config file.
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
@@ -13,13 +13,21 @@ displays env vars set from existing environment and loaded from config file in s
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 ## Usage
 
-    $ rpenv <env>
+    $ rpenv -v
 
 or
 
-    $ rpenv <env> <cmd>
+    $ rpenv -version
 
-where `<env>` is one of `ci`, `qa`, or `prod` (`production` should also work) and `<cmd>` is the desired command you wish to run. If called without a `<cmd>`, `rpenv` will return a list of all the env vars in the `/etc/rentpath/environment.cfg` file merged with your current environment variables (i.e. whatever `/usr/bin/env` would return). When run with a `<cmd>`, it will execute that `<cmd>` after setting the environment with the values returned if `rpenv` is run without a `<cmd>`.
+displays rpenv version information
+
+    $ rpenv [-skip-local] <env>
+
+or
+
+    $ rpenv [-skip-local] <env> <cmd>
+
+where `<env>` is one of `ci`, `qa`, or `prod` (`production` should also work) and `<cmd>` is the desired command you wish to run. If called without a `<cmd>`, `rpenv` will return a list of all the env vars in the `/etc/rentpath/environment.cfg` file merged with your current environment variables (i.e. whatever `/usr/bin/env` would return), or with `-skip-local`, your current environment variables will not be merged (the envs are still there from the parent process, just not displayed). When run with a `<cmd>`, it will execute that `<cmd>` after setting the environment with the values returned if `rpenv` is run without a `<cmd>`.
 
 ## Testing
 

--- a/rpenv.spec
+++ b/rpenv.spec
@@ -1,5 +1,5 @@
 Name:   rpenv
-Version:  3.0.5
+Version:  3.1.0
 Release:  1%{?dist}
 Summary: displays env vars set from existing environment.
 Source0: rpenv.go
@@ -39,6 +39,9 @@ rm -rf %{buildroot}
 
 
 %changelog
+* Mon Mar 19 2018 Alan Voss <avoss@rentpath.com> - 3.1.0
+- Adding -skip-local flag; skips locals on output (no command passed)
+
 * Wed Feb 14 2018 Alan Voss <avoss@rentpath.com> - 3.0.5
 - Cross-compilation for linux didn't work for user dir query
 

--- a/rpenv_test.go
+++ b/rpenv_test.go
@@ -57,18 +57,37 @@ func TestEnvVars(t *testing.T) {
 	if !*system {
 		t.Skip()
 	} else {
-		results := envVars(envUri("ci"))
-		passes := 2
+		results := envVars(envUri("ci"), false)
+		passes := 3
 		for _, keyValue := range results {
-			if keyValue == "HOME" {
+			splitKeyValue := strings.Split(keyValue, "=")
+			key := splitKeyValue[0]
+			if key == "HOME" {
 				passes--
 			}
-			if strings.HasPrefix(keyValue, "APPLICATION") {
+			if key == "APPLICATIONS_ROOT" {
+				passes--
+			}
+			if key == "PATH" {
 				passes--
 			}
 		}
 		if passes > 0 {
-			fmt.Fprintln(os.Stderr, "Expected envVars to return environment variables, but couldn't find 'HOME' or 'APPLICATION_*' vars which should be present.")
+			fmt.Fprintln(os.Stderr, "Expected envVars with no skip local to return environment variables, but couldn't find 'HOME', 'APPLICATIONS_ROOT', or 'PATH' vars which should be present.")
+			t.Errorf("Environment variables found: %q", results)
+		}
+
+		results = envVars(envUri("ci"), true)
+		fails := 0
+		for _, keyValue := range results {
+			splitKeyValue := strings.Split(keyValue, "=")
+			key := splitKeyValue[0]
+			if key == "PATH" {
+				fails++
+			}
+		}
+		if fails > 0 {
+			fmt.Fprintln(os.Stderr, "Expected envVars with skip local to return environment variables, but those shouldn't include the 'PATH' var.")
 			t.Errorf("Environment variables found: %q", results)
 		}
 	}


### PR DESCRIPTION
adding a `-skip-local` or `--skip-local` flag to not output local envs in the output of a command-less argument execution of `rpenv`.