### PR TITLE
fixes data where values w/ = caused rogue split

### DIFF
--- a/rpenv.go
+++ b/rpenv.go
@@ -14,7 +14,7 @@ import (
 	"syscall"
 )
 
-const AppVersion = "3.1.0"
+const AppVersion = "3.1.1"
 const ConfigPath = ".config/.rpenv"
 
 func main() {
@@ -66,15 +66,15 @@ func envVars(envUri string, skipLocalEnvs bool) []string {
 
 	for _, kvPair := range rawVars {
 		if !strings.HasPrefix(kvPair, "#") && kvPair != "" {
-			kvArray := strings.Split(strings.Replace(kvPair, "\"", "", -1), "=")
-			envsMap[kvArray[0]] = kvArray[1]
+			key, value := splitSimple(strings.Replace(kvPair, "\"", "", -1), "=")
+			envsMap[key] = value
 		}
 	}
 
 	if !skipLocalEnvs {
 		for _, kvPair := range os.Environ() {
-			kvArray := strings.Split(kvPair, "=")
-			envsMap[kvArray[0]] = kvArray[1]
+			key, value := splitSimple(kvPair, "=")
+			envsMap[key] = value
 		}
 	}
 
@@ -167,9 +167,17 @@ func readConfig(configFile string) map[string]string {
 	}
 	configSlurp := strings.Trim(string(config), " \n")
 	for _, line := range strings.Split(configSlurp, "\n") {
-		fields := strings.Split(line, "=")
-		mymap[fields[0]] = fields[1]
+		key, value := splitSimple(line, "=")
+		mymap[key] = value
 	}
 
 	return mymap
+}
+
+// only splits on first instance of chr
+func splitSimple(str string, chr string) (string, string) {
+	split_up := strings.Split(str, "=")
+	key := split_up[0]
+	value := strings.Join(split_up[1:], "=")
+	return key, value
 }

--- a/rpenv.spec
+++ b/rpenv.spec
@@ -1,5 +1,5 @@
 Name:   rpenv
-Version:  3.1.0
+Version:  3.1.1
 Release:  1%{?dist}
 Summary: displays env vars set from existing environment.
 Source0: rpenv.go
@@ -39,6 +39,9 @@ rm -rf %{buildroot}
 
 
 %changelog
+* Mon Apr 9 2018 Alan Voss <avoss@rentpath.com> - 3.1.1
+- Correcting parsing of values with = in them
+
 * Mon Mar 19 2018 Alan Voss <avoss@rentpath.com> - 3.1.0
 - Adding -skip-local flag; skips locals on output (no command passed)
 
@@ -57,7 +60,7 @@ rm -rf %{buildroot}
 * Tue Jan 30 2018 Alan Voss <avoss@rentpath.com> - 3.0.1
 - Fixing README and various version errors in repo
 
-* Wed Aug 28 2018 Dan McGuire <dmcguire@rentpath.com> - 3.0.0
+* Mon Jan 29 2018 Dan McGuire <dmcguire@rentpath.com> - 3.0.0
 - adds the jimlawless/cfg vendor dependency
 - moves urls out of the repo and into configs
 

--- a/rpenv_test.go
+++ b/rpenv_test.go
@@ -108,3 +108,13 @@ func TestExecuteCommand(t *testing.T) {
 
 	restoreStd(writerStdout, writerStderr, stdout, stderr)
 }
+
+func TestSplitSimple(t *testing.T) {
+	key, value := splitSimple("SIMPLE=\"SPLIT=ALGO\"", "=")
+	if key != "SIMPLE" {
+		t.Errorf("SPLIT KEY appears incorrect")
+	}
+	if value != "\"SPLIT=ALGO\"" {
+		t.Errorf("SPLIT VALUE appears incorrect")
+	}
+}


### PR DESCRIPTION
[Card](https://rentpath.leankit.com/card/650382632)

No built-in that I can find, so made my own splitter that only splits on the first instance of a split string.  Good enough.

Test by:

before (version 3.1.0), pointing at new ci, fail, with this fix, succeed.

Get urls from Alan.  I'm not posting here, as this is open source.
